### PR TITLE
Update shipping address logic and switch API to production

### DIFF
--- a/ecom/src/app/cart/page.tsx
+++ b/ecom/src/app/cart/page.tsx
@@ -135,12 +135,10 @@ const CartPage = () => {
                   );
                   
                   // If no default shipping found, use the first shipping address
-                  const firstShipping = userData.user.addresses.find(
-                    (addr: Address) => addr.type != ''
-                  );
+                  const firstShipping = userData.user.addresses[0]
                   
                   defaultShipping = defaultShipping || firstShipping || null;
-                  console.log("🚀 ~ loadUserProfile ~ defaultShipping:", defaultShipping)
+                  // console.log("🚀 ~ loadUserProfile ~ defaultShipping:", defaultShipping)
                   isInternational = (defaultShipping?.country !== 'India');
                 }
                 

--- a/ecom/src/app/lib/api.ts
+++ b/ecom/src/app/lib/api.ts
@@ -2,8 +2,8 @@
 import axios from 'axios';
 
 // API base URL
-// export const API_URL = "https://ecom-turborepo.onrender.com/api"
-export const API_URL = "http://localhost:7003/api"
+export const API_URL = "https://ecom-turborepo.onrender.com/api"
+// export const API_URL = "http://localhost:7003/api"
 
 
 // Create an axios instance with default configuration


### PR DESCRIPTION
Revise the logic for determining the default shipping address in the CartPage and change the API URL to point to the production environment.

## Summary by Sourcery

Update shipping address selection logic and switch to production API endpoint

Enhancements:
- Simplified shipping address selection by using the first address in the user's address list as the default

Deployment:
- Switched API endpoint from localhost to production URL

Chores:
- Removed debug console log statement